### PR TITLE
dockerfile maven plugin functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM java:8
+FROM openjdk:11
 ADD target/test-service-0.1.0-SNAPSHOT.jar /app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -216,12 +216,13 @@
                     </dependency>
                 </dependencies>
 
+                <configuration>
+                    <repository>${env.DOCKER_REGISTRY_IP}:5000/${project.artifactId}</repository>
+                </configuration>
+
                 <executions>
                     <execution>
                         <id>build image</id>
-                        <configuration>
-                            <repository>${env.DOCKER_REGISTRY_IP}:5000/${project.artifactId}</repository>
-                        </configuration>
                         <phase>deploy</phase>
                         <goals>
                             <goal>build</goal>
@@ -230,7 +231,7 @@
                     <execution>
                         <id>branch tag</id>
                         <configuration>
-                            <repository>${env.DOCKER_REGISTRY_IP}:5000/${project.artifactId}:${scmBranch}</repository>
+                            <tag>${scmBranch}</tag>
                         </configuration>
                         <phase>deploy</phase>
                         <goals>
@@ -240,7 +241,7 @@
                     <execution>
                         <id>version tag</id>
                         <configuration>
-                            <repository>${env.DOCKER_REGISTRY_IP}:5000/${project.artifactId}:${current-version}</repository>
+                            <tag>${current-version}</tag>
                         </configuration>
                         <phase>deploy</phase>
                         <goals>
@@ -249,9 +250,6 @@
                     </execution>
                     <execution>
                         <id>push image</id>
-                        <configuration>
-                            <repository>${env.DOCKER_REGISTRY_IP}:5000/${project.artifactId}</repository>
-                        </configuration>
                         <phase>deploy</phase>
                         <goals>
                             <goal>push</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -192,14 +192,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.3.1.RELEASE</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <!-- Нужен для сборки docker image с тегами, и его пуша в docker registry -->
             <plugin>
@@ -208,11 +200,10 @@
                 <version>${dockerfile-maven-plugin.version}</version>
 
                 <dependencies>
-                    <!-- Замещает slf4j по умолчанию, который вызывал бы ошибку -->
                     <dependency>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-simple</artifactId>
-                        <version>1.7.21</version>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-logging</artifactId>
+                        <version>${project.parent.version}</version>
                     </dependency>
                 </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,8 @@
         <postgres.driver.version>42.2.14</postgres.driver.version>
 
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
-        <docker-maven-plugin.version>1.0.0</docker-maven-plugin.version>
+        <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
         <flyway.version>6.5.1</flyway.version>
-        <dockerfile-maven-version>1.4.13</dockerfile-maven-version>
     </properties>
 
     <dependencies>
@@ -189,98 +188,77 @@
                     <doUpdate>false</doUpdate>
                 </configuration>
             </plugin>
+            <!-- Нужен для сборки толстого jar, наследуется от parent -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.3.1.RELEASE</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Нужен для сборки docker image с тегами, и его пуша в docker registry -->
             <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>${dockerfile-maven-version}</version>
+                <version>${dockerfile-maven-plugin.version}</version>
+
+                <dependencies>
+                    <!-- Замещает slf4j по умолчанию, который вызывал бы ошибку -->
+                    <dependency>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-simple</artifactId>
+                        <version>1.7.21</version>
+                    </dependency>
+                </dependencies>
+
                 <executions>
                     <execution>
-                        <id>default</id>
+                        <id>build image</id>
+                        <configuration>
+                            <repository>${env.DOCKER_REGISTRY_IP}:5000/${project.artifactId}</repository>
+                        </configuration>
+                        <phase>deploy</phase>
                         <goals>
                             <goal>build</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>branch tag</id>
+                        <configuration>
+                            <repository>${env.DOCKER_REGISTRY_IP}:5000/${project.artifactId}:${scmBranch}</repository>
+                        </configuration>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>tag</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>version tag</id>
+                        <configuration>
+                            <repository>${env.DOCKER_REGISTRY_IP}:5000/${project.artifactId}:${current-version}</repository>
+                        </configuration>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>tag</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>push image</id>
+                        <configuration>
+                            <repository>${env.DOCKER_REGISTRY_IP}:5000/${project.artifactId}</repository>
+                        </configuration>
+                        <phase>deploy</phase>
+                        <goals>
                             <goal>push</goal>
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <repository>${env.DOCKER_REGISTRY_IP}:5000/${project.artifactId}</repository>
-                    <dockerfile.contextDirectory>.</dockerfile.contextDirectory>
-                    <tag>${project.version}</tag>
-                    <buildArgs>
-                        <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
-                    </buildArgs>
-                </configuration>
             </plugin>
-            <!-- Нужен для сборки docker image с тегами, и его пуша в docker registry -->
-<!--            <plugin>-->
-
-<!--                <groupId>com.spotify</groupId>-->
-<!--                <artifactId>docker-maven-plugin</artifactId>-->
-<!--                <version>${docker-maven-plugin.version}</version>-->
-
-<!--                <configuration>-->
-
-<!--                    <image>${project.artifactId}</image>-->
-<!--                    <newName>${env.DOCKER_REGISTRY_IP}:5000/${project.artifactId}</newName>-->
-
-<!--                    <imageName>${project.artifactId}</imageName>-->
-<!--&lt;!&ndash;                    <forceTags>true</forceTags>&ndash;&gt;-->
-<!--&lt;!&ndash;                    <imageTags>&ndash;&gt;-->
-<!--&lt;!&ndash;                        <imageTag>${scmBranch}</imageTag>&ndash;&gt;-->
-<!--&lt;!&ndash;                        <imageTag>${current-version}</imageTag>&ndash;&gt;-->
-<!--&lt;!&ndash;                    </imageTags>&ndash;&gt;-->
-<!--                    <dockerDirectory>.</dockerDirectory>-->
-<!--                    <dockerHost>http://${env.DOCKER_IP}:2375</dockerHost>-->
-<!--                    <resources>-->
-<!--                        <resource>-->
-<!--                            <directory>${project.build.directory}</directory>-->
-<!--                            <include>${project.build.finalName}.jar</include>-->
-<!--                        </resource>-->
-<!--                    </resources>-->
-<!--                </configuration>-->
-
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        <id>build-image</id>-->
-<!--                        <phase>package</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>build</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                    <execution>-->
-<!--                        <id>tag-image</id>-->
-<!--                        <phase>package</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>tag</goal>-->
-<!--                        </goals>-->
-<!--                        <configuration>-->
-<!--                            <forceTags>true</forceTags>-->
-<!--                            <newName>${scmBranch}</newName>-->
-<!--                            <newName>${current-version}</newName>-->
-<!--                        </configuration>-->
-<!--                    </execution>-->
-<!--&lt;!&ndash;                    <execution>&ndash;&gt;-->
-<!--&lt;!&ndash;                        <id>version tag</id>&ndash;&gt;-->
-<!--&lt;!&ndash;                        <configuration>&ndash;&gt;-->
-<!--&lt;!&ndash;                            <newName>${current-version}</newName>&ndash;&gt;-->
-<!--&lt;!&ndash;                        </configuration>&ndash;&gt;-->
-<!--&lt;!&ndash;                        <phase>deploy</phase>&ndash;&gt;-->
-<!--&lt;!&ndash;                        <goals>&ndash;&gt;-->
-<!--&lt;!&ndash;                            <goal>tag</goal>&ndash;&gt;-->
-<!--&lt;!&ndash;                        </goals>&ndash;&gt;-->
-<!--&lt;!&ndash;                    </execution>&ndash;&gt;-->
-<!--                    <execution>-->
-<!--                        <id>push-image</id>-->
-<!--                        <configuration>-->
-<!--                            <imageName>${env.DOCKER_REGISTRY_IP}:5000/${project.artifactId}</imageName>-->
-<!--                        </configuration>-->
-<!--                        <phase>deploy</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>push</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                </executions>-->
-<!--            </plugin>-->
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Docker maven plugin заменен на dockerfile maven plugin. Функциональность прежняя, но больше нет стек-трейсов (для этого плагину потребовалась небольшая дополнительная зависимость). В pom добавлена цель repackage для плагина spring-boot-maven-plugin, который загружается в сборку вместе с parent. Это нужно для сборки толстого jar, который можно поместить в докер image (поменял ему родительский образ, потому что там по ошибке стоял не jdk 11). В docker registry есть возможность аутентификации, но проще будет закрыть 5000 порт на машине, чтобы к нему можно было подключаться только локально.